### PR TITLE
Fix xml2js version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug": "^3.2.6",
     "xml-crypto": "^1.4.0",
     "xml-encryption": "^1.0.0",
-    "xml2js": "0.4.x",
+    "xml2js": "^0.4.20",
     "xmlbuilder": "^15.1.1",
     "xmldom": "^0.3.0"
   },


### PR DESCRIPTION
I was trying to use your library and I got an error `parser.parseStringPromise is not a function`, then I have noticed that you call `parseStringPromise()` in two points of the code:

```
/node-saml/src/saml.js
  231,33:       const doc2 = await parser.parseStringPromise(xml);
  822,30:     const doc = await parser.parseStringPromise(xml);
```

But this function is only available in release 0.4.20 of xml2js lib.
The commit: https://github.com/Leonidas-from-XIV/node-xml2js/commit/c7597111d758f8850fc40810a9fd4ef58d922052
Commits starting from 0.4.19: https://github.com/Leonidas-from-XIV/node-xml2js/compare/0.4.19...master

![image](https://user-images.githubusercontent.com/11397715/88462642-575d6e80-ce83-11ea-9caf-9e6586de8aa4.png)
