### PR TITLE
Return success true on valid signed assertion

### DIFF
--- a/src/saml.js
+++ b/src/saml.js
@@ -964,7 +964,7 @@ class SAML {
     profile.getAssertion = () => parsedAssertion;
     profile.getSamlResponseXml = () => samlResponseXml;
 
-    return {profile, success: false};
+    return {profile, success: true};
   }
 
   _checkTimestampsValidityError(nowMs, notBefore, notOnOrAfter) {


### PR DESCRIPTION
_processValidlySignedAssertion() throws exceptions on all error conditions.  At the end of the function the returned object's success property should be set to true.